### PR TITLE
Use rand() instead of query.id&1

### DIFF
--- a/rebinder.c
+++ b/rebinder.c
@@ -219,7 +219,7 @@ int main(int argc, char **argv)
         }
 
         // Choose a random label to return based on ID.
-        if (!parse_ip4_label(&reply.rdata, (query.id & 1) ? query.labels.primary.label : query.labels.secondary.label)) {
+        if (!parse_ip4_label(&reply.rdata, (rand()%2) ? query.labels.primary.label : query.labels.secondary.label)) {
             warnx("client provided an invalid ip4 address, ignoring reqest");
             reply.flags.rcode = ns_r_nxdomain; //lint !e641
             goto error;


### PR DESCRIPTION
I run into an issue where the query ids were always even. This prevented rbndr to return a random value. This change uses a source of randomness that doesn't rely on the client doing the right thing.